### PR TITLE
SCR-211: 土地詳細画面修正

### DIFF
--- a/resources/views/facilities/land-info/partials/display-card.blade.php
+++ b/resources/views/facilities/land-info/partials/display-card.blade.php
@@ -73,7 +73,7 @@
             'type' => 'standard',
             'cells' => [
                 ['label' => '家賃', 'value' => $landInfo->monthly_rent, 'type' => 'currency'],
-                ['label' => '', 'value' => '-', 'type' => 'text', 'class' => 'text-center'],
+                ['label' => '-', 'value' => '-', 'type' => 'text'],
                 [
                     'label' => '契約書・覚書', 
                     'value' => $landInfo->lease_contract_pdf_name ? route('facilities.land-info.download', ['facility' => $facility, 'type' => 'lease_contract']) : null, 
@@ -250,6 +250,21 @@
 @endphp
 
 <!-- 管理会社情報・オーナー情報テーブル -->
+<style>
+    .row .col-md-6 .facility-info-card.detail-card-improved .card-header {
+        background: #f8f9fa !important;
+        background-color: #f8f9fa !important;
+        color: #212529 !important;
+    }
+
+    .row .col-md-6 .facility-info-card .card-header h5 {
+        color: #212529 !important;
+    }
+
+    .facility-basic-info-table-clean tbody tr:nth-child(3) td:nth-child(3) {
+        background-color: #f8f9fa !important;
+    }
+</style>
 <div class="row mb-3">
     <!-- 管理会社情報テーブル -->
     <div class="col-md-6">

--- a/resources/views/facilities/land-info/partials/display-card.blade.php
+++ b/resources/views/facilities/land-info/partials/display-card.blade.php
@@ -28,7 +28,7 @@
                 [
                     'label' => '所有', 
                     'value' => $ownershipBadge, 
-                    'type' => 'badge',
+                    'type' => 'text',
                     'colspan' => 3,
                     'options' => ['badge_class' => $ownershipBadgeClass]
                 ],
@@ -108,7 +108,7 @@
             [
                 'label' => '自動更新の有無', 
                 'value' => $autoRenewalBadge, 
-                'type' => 'badge',
+                'type' => 'text',
                 'options' => ['badge_class' => $autoRenewalBadgeClass]
             ],
             ['label' => '契約年数', 'value' => $landInfo->contract_period_text, 'type' => 'text'],


### PR DESCRIPTION
・管理会社情報とオーナー情報のテキスト、背景を他のデザインに合わせる
・契約書のセルを1つ右にずらす
・管理会社情報、オーナー情報のデザイン修正